### PR TITLE
Made LoggingClient compatible with Client

### DIFF
--- a/lib/Doctrine/CouchDB/HTTP/LoggingClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/LoggingClient.php
@@ -58,11 +58,11 @@ class LoggingClient implements Client
         $this->client = $client;
     }
 
-    public function request($method, $path, $data = null, $raw = false)
+    public function request($method, $path, $data = null, $raw = false, array $headers = array())
     {
         $start = microtime(true);
         
-        $response = $this->client->request($method, $path, $data, $raw);
+        $response = $this->client->request($method, $path, $data, $raw, $headers);
         
         $duration = microtime(true) - $start;
         $this->requests[] = array(


### PR DESCRIPTION
Made declaration of Doctrine\CouchDB\HTTP\LoggingClient::request() compatible with new Doctrine\CouchDB\HTTP\Client::request($method, $path, $data = NULL, $raw = false, array $headers = Array) definition
